### PR TITLE
Insert bar chart header after sorting dataset

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -100,8 +100,6 @@ async function draw() {
         arrayToDrawBar.push([teamName, arrayToDraw[arrayToDraw.length - 1][i + 1]]);
       });
 
-      arrayToDrawBar.unshift(['チーム名', 'スコア']);
-
       arrayToDrawBar.sort((a, b) => {
         if (a[1] < b[1]) {
           return 1;
@@ -111,6 +109,8 @@ async function draw() {
           return 0;
         }
       });
+
+      arrayToDrawBar.unshift(['チーム名', 'スコア']);
 
       const dataBar = new google.visualization.arrayToDataTable(arrayToDrawBar);
       const barChart = new google.visualization.BarChart(document.getElementById('barChart'));


### PR DESCRIPTION
First of all, Thank you for creating this portal! Our team uses this for private ISUCON.

## WHY

Bar graph "最新のスコア" is not show with the below error:

![image](https://user-images.githubusercontent.com/680124/30770498-5d2fbe9a-a06d-11e7-8b3e-783de14f23d2.png)

Dataset was sorted with the header `チーム名, スコア`, so a certain score record was recognized as header...

## WHAT

Insert header to dataset after sorting all records.

![image](https://user-images.githubusercontent.com/680124/30770509-a7acea24-a06d-11e7-8ed3-8522b1db6c93.png)
